### PR TITLE
Upgrade axios dependency to v1.13.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.13.6",
     "bfv-api": "^1.3.3",
     "exceljs": "^4.4.0",
     "ics": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,11 +9,11 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: ^1.13.5
-        version: 1.13.5
+        specifier: ^1.13.6
+        version: 1.13.6
       bfv-api:
         specifier: ^1.3.3
-        version: 1.3.3(axios@1.13.5)
+        version: 1.3.3(axios@1.13.6)
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -72,8 +72,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.13.5:
-    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
+  axios@1.13.6:
+    resolution: {integrity: sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -506,9 +506,9 @@ snapshots:
     dependencies:
       undici-types: 7.8.0
 
-  '@zodios/core@10.9.6(axios@1.13.5)(zod@3.25.76)':
+  '@zodios/core@10.9.6(axios@1.13.6)(zod@3.25.76)':
     dependencies:
-      axios: 1.13.5
+      axios: 1.13.6
       zod: 3.25.76
 
   archiver-utils@2.1.0:
@@ -551,7 +551,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.13.5:
+  axios@1.13.6:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -563,9 +563,9 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bfv-api@1.3.3(axios@1.13.5):
+  bfv-api@1.3.3(axios@1.13.6):
     dependencies:
-      '@zodios/core': 10.9.6(axios@1.13.5)(zod@3.25.76)
+      '@zodios/core': 10.9.6(axios@1.13.6)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - axios


### PR DESCRIPTION
## Summary
This pull request updates the axios HTTP client library to the latest patch version.

## Changes
- Bumped axios from `^1.13.5` to `^1.13.6`

## Details
This is a minor dependency update that brings in the latest patch release of axios v1.13. The lockfile has been updated to reflect the transitive dependency changes from this upgrade.

https://claude.ai/code/session_01L2BV9JzqtLqgYidUMPiyVx