### PR TITLE
Update dependencies and GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish-gh-pages.yml
+++ b/.github/workflows/publish-gh-pages.yml
@@ -26,7 +26,7 @@ jobs:
           node-version: 20
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         with:
           version: 8
 

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
   "license": "ISC",
   "packageManager": "pnpm@10.14.0",
   "dependencies": {
-    "axios": "^1.14.0",
+    "axios": "^1.15.0",
     "bfv-api": "^1.3.3",
     "exceljs": "^4.4.0",
     "ics": "^3.11.0",
     "json2csv": "6.0.0-alpha.2"
   },
   "devDependencies": {
-    "@types/node": "^25.5.2",
+    "@types/node": "^25.6.0",
     "typescript": "^6.0.2"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
   .:
     dependencies:
       axios:
-        specifier: ^1.14.0
-        version: 1.14.0
+        specifier: ^1.15.0
+        version: 1.15.0
       bfv-api:
         specifier: ^1.3.3
-        version: 1.3.3(axios@1.14.0)
+        version: 1.3.3(axios@1.15.0)
       exceljs:
         specifier: ^4.4.0
         version: 4.4.0
@@ -28,8 +28,8 @@ importers:
         version: 6.0.0-alpha.2
     devDependencies:
       '@types/node':
-        specifier: ^25.5.2
-        version: 25.5.2
+        specifier: ^25.6.0
+        version: 25.6.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -48,8 +48,8 @@ packages:
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
 
-  '@types/node@25.5.2':
-    resolution: {integrity: sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==}
+  '@types/node@25.6.0':
+    resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
   '@zodios/core@10.9.6':
     resolution: {integrity: sha512-aH4rOdb3AcezN7ws8vDgBfGboZMk2JGGzEq/DtW65MhnRxyTGRuLJRWVQ/2KxDgWvV2F5oTkAS+5pnjKbl0n+A==}
@@ -75,8 +75,8 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  axios@1.14.0:
-    resolution: {integrity: sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==}
+  axios@1.15.0:
+    resolution: {integrity: sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -452,8 +452,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  undici-types@7.18.2:
-    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
+  undici-types@7.19.2:
+    resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
   unzipper@0.10.14:
     resolution: {integrity: sha512-ti4wZj+0bQTiX2KmKWuwj7lhV+2n//uXEotUmGuQqrbVZSEGFMbI68+c6JCQ8aAmUWYvtHEz2A8K6wXvueR/6g==}
@@ -506,13 +506,13 @@ snapshots:
 
   '@types/node@14.18.63': {}
 
-  '@types/node@25.5.2':
+  '@types/node@25.6.0':
     dependencies:
-      undici-types: 7.18.2
+      undici-types: 7.19.2
 
-  '@zodios/core@10.9.6(axios@1.14.0)(zod@3.25.76)':
+  '@zodios/core@10.9.6(axios@1.15.0)(zod@3.25.76)':
     dependencies:
-      axios: 1.14.0
+      axios: 1.15.0
       zod: 3.25.76
 
   archiver-utils@2.1.0:
@@ -555,7 +555,7 @@ snapshots:
 
   asynckit@0.4.0: {}
 
-  axios@1.14.0:
+  axios@1.15.0:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -567,9 +567,9 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  bfv-api@1.3.3(axios@1.14.0):
+  bfv-api@1.3.3(axios@1.15.0):
     dependencies:
-      '@zodios/core': 10.9.6(axios@1.14.0)(zod@3.25.76)
+      '@zodios/core': 10.9.6(axios@1.15.0)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
       - axios
@@ -930,7 +930,7 @@ snapshots:
 
   typescript@6.0.2: {}
 
-  undici-types@7.18.2: {}
+  undici-types@7.19.2: {}
 
   unzipper@0.10.14:
     dependencies:


### PR DESCRIPTION
## Summary
This PR updates project dependencies to their latest versions and upgrades the GitHub Actions workflow to use a newer version of the pnpm setup action.

## Key Changes
- **Dependencies:**
  - Updated `axios` from `^1.14.0` to `^1.15.0`
  - Updated `@types/node` from `^25.5.2` to `^25.6.0`

- **GitHub Actions:**
  - Upgraded `pnpm/action-setup` from `v5` to `v6`

## Details
These are routine dependency maintenance updates to keep the project current with the latest stable releases. The pnpm action upgrade ensures compatibility with the latest GitHub Actions environment and best practices.

https://claude.ai/code/session_0159MheC1vTB73Nh3d4yCPcp